### PR TITLE
Major refactor of renderers to to use transparency in palette

### DIFF
--- a/clover/cli/utilities.py
+++ b/clover/cli/utilities.py
@@ -1,6 +1,7 @@
 import importlib
 
 import click
+import os
 import numpy
 from PIL.Image import ANTIALIAS
 from pyproj import Proj
@@ -19,7 +20,12 @@ def render_image(renderer, data, filename, scale=1, flip_y=False):
     img = renderer.render_image(data)
     if scale != 1:
         img = img.resize((numpy.array(data.shape[::-1]) * scale).astype(numpy.uint), ANTIALIAS)
-    img.save(filename)
+
+    kwargs = {}
+    if os.path.splitext(filename)[1].lower() == '.png':
+        kwargs['optimize'] = True
+
+    img.save(filename, **kwargs)
 
 
 def colormap_to_stretched_renderer(colormap, colorspace='hsv', filenames=None, variable=None, fill_value=None, mask=None):
@@ -54,7 +60,6 @@ def palette_to_stretched_renderer(palette_path, values, filenames=None, variable
     if not len(values) > 1:
         raise ValueError('Must provide at least 2 values for palette-based stretched renderer')
 
-    statistics = None
     if 'min' in values or 'max' in values:
         if not filenames and variable:
             raise ValueError('filenames and variable are required inputs to use palette with statistics')
@@ -103,7 +108,6 @@ def get_leaflet_anchors(bbox):
 
     wgs84_bbox = bbox.project(Proj(init='EPSG:4326'))
     return [[wgs84_bbox.ymin, wgs84_bbox.xmin], [wgs84_bbox.ymax, wgs84_bbox.xmax]]
-
 
 def get_mask(mask_path):
     """

--- a/clover/render/renderers/__init__.py
+++ b/clover/render/renderers/__init__.py
@@ -55,11 +55,6 @@ class RasterRenderer(object):
 
         mask = False if self.fill_value is None else (data == self.fill_value)
         return numpy.ma.masked_array(data, mask=mask)
-        #
-        # if self.fill_value is not None:
-        #     return numpy.ma.masked_array(data, mask=data == self.fill_value)
-        # else:
-        #     return numpy.ma.masked_array(data)
 
     def _create_image(self, image_data, size):
         """

--- a/clover/render/renderers/stretched.py
+++ b/clover/render/renderers/stretched.py
@@ -10,20 +10,39 @@ from clover.render.renderers.legend import LegendElement
 def getRendererClass():
     return StretchedRenderer
 
+
+# TODO: params for palette size and optimization
+
 class StretchedRenderer(RasterRenderer):
-    def __init__(self, colormap, fill_value=None, background_color=None, method="linear", colorspace="hsv"):
+    def __init__(self,
+                 colormap,
+                 fill_value=None,
+                 background_color=None,
+                 method="linear",
+                 colorspace="hsv",
+                 palette_size=None):
         """
         Maps a stretched color palette against the data range according to a particular method
         (e.g., linear from min to max value).
 
         :param linear: apply a linear stretch between min and max values
         :param colorspace: the colorspace in which to do color interpolation
+        :param palette_size: if provided, will be used as palette size.  Otherwise will default to 255 if > 20 colors in colormap, otherwise 90
         """
 
         assert len(colormap) >= 2
 
         self.method = method
         self.colorspace = colorspace
+
+        if palette_size is not None:
+            assert palette_size <= 255
+            self.palette_size = palette_size
+        elif len(colormap) > 20:
+            self.palette_size = 255
+        else:
+            self.palette_size = 90
+
         super(StretchedRenderer, self).__init__(colormap, fill_value, background_color)
 
     def get_legend(self, image_width=20, image_height=100, ticks=None, breaks=None, max_precision=6, discrete_images=False):
@@ -78,36 +97,27 @@ class StretchedRenderer(RasterRenderer):
         else:
             raise NotImplementedError("Legends not built for other stretched renderer methods")
 
+    # TODO: handle cropping of stretched values properly (truncate above and below and set to background value?)
     def render_image(self, data, row_major_order=True):
         num_colors = self.palette.shape[0]
         factor = float(num_colors) / float(self.max_value - self.min_value)
-        img_size = data.shape[::-1] if row_major_order else data.shape[:2] # have to invert because PIL thinks about this backwards
         values = self._mask_fill_value(data.ravel())
 
-        #derive palette index, and clip to [0,num_colors]
-        image_data = ((values - self.min_value) * factor).astype(numpy.int).clip(0, num_colors-1).astype(numpy.uint8)
+        # derive palette index, and clip to [0, num_colors - 1]
+        stretched = ((values - self.min_value) * factor).astype(numpy.int)
+        image_data = stretched.clip(0, num_colors-1).astype(numpy.uint8)
 
-        if self.background_color:
-            image_data[values.mask] = num_colors
-
-        img = Image.frombuffer("P", img_size, image_data, "raw", "P", 0, 1)
-        self._set_image_palette(img)
-
-        if self.background_color is None and values.mask.shape:
-            img = self._apply_transparency_mask_to_image(img, (values.mask == False))
-
-        return img
+        # have to invert dimensions because PIL thinks about this backwards
+        size = data.shape[::-1] if row_major_order else data.shape[:2]
+        return self._create_image(image_data, size)
 
     def _generate_palette(self):
         self.min_value = self.colormap[0][0]
         self.max_value = self.colormap[len(self.colormap)-1][0]
-        colors = numpy.asarray([entry[1].to_tuple() for entry in self.colormap]).astype(numpy.uint8)
+        colors = numpy.asarray([c[1].to_tuple() for c in self.colormap]).astype(numpy.uint8)
 
         if self.method == "linear":
-            palette_size = 128  # visually indistinguishable from 255 value palette, with smaller file size
-            if len(self.colormap) > 20:
-                palette_size = 255
-            self.palette = interpolate_linear(colors, self.values, palette_size, colorspace=self.colorspace)
+            self.palette = interpolate_linear(colors, self.values, self.palette_size, colorspace=self.colorspace)
         else:
             raise NotImplementedError("Other stretched render methods not built!")
 

--- a/clover/render/renderers/tests/test_renderers.py
+++ b/clover/render/renderers/tests/test_renderers.py
@@ -8,12 +8,12 @@ from clover.render.renderers.utilities import get_renderer_by_name
 
 
 def test_stretched_renderer(tmpdir):
-    data = numpy.zeros((100,100))
+    data = numpy.zeros((100, 100))
     for i in range(0, 100):
         data[i] = i
     colors = (
-        (data.min(), Color(255,0,0,255)),
-        (data.max(), Color(0,0,255,255))
+        (data.min(), Color(255, 0, 0, 255)),
+        (data.max(), Color(0, 0, 255, 255))
     )
     renderer = StretchedRenderer(colors)
 
@@ -21,12 +21,12 @@ def test_stretched_renderer(tmpdir):
 
     img = renderer.render_image(data)
     assert len(img.getpalette()) / 3 == 256
-    assert img.size == (100,100)
+    assert img.size == (100, 100)
     img.save(str(tmpdir.join("stretched.png")))
 
-    legend = renderer.get_legend(20,20)
+    legend = renderer.get_legend(20, 20)
     assert len(legend) == 1
-    assert legend[0].image.size == (20,20)
+    assert legend[0].image.size == (20, 20)
     legend[0].image.save(str(tmpdir.join("stretched_legend.png")))
 
     legend = renderer.get_legend(20, 20, discrete_images=True)
@@ -34,20 +34,20 @@ def test_stretched_renderer(tmpdir):
     assert legend[0].image.size == (20, 20)
 
     assert cmp(renderer.serialize(), {
-        'colors': [(0.0, '#FF0000'), (99.0, '#0000FF')],
+        'colors': [(0.0, '#F00'), (99.0, '#00F')],
         'type': 'stretched',
         'options': {'color_space': 'hsv'}
     }) == 0
 
 
 def test_classified_rendererer(tmpdir):
-    data = numpy.zeros((100,100))
+    data = numpy.zeros((100, 100))
     for i in range(0, 100):
         data[i] = i
     colors = (
-        (10, Color(255,0,0,255)),
-        (50, Color(0,255,0,255)),
-        (data.max(), Color(0,0,255,255))
+        (10, Color(255, 0, 0, 255)),
+        (50, Color(0, 255, 0, 255)),
+        (data.max(), Color(0, 0, 255, 255))
     )
     renderer = ClassifiedRenderer(colors)
 
@@ -55,34 +55,33 @@ def test_classified_rendererer(tmpdir):
 
     img = renderer.render_image(data)
     img.save(str(tmpdir.join("classified.png")))
-    assert img.palette.palette == '\xff\x00\x00\x00\xff\x00\x00\x00\xff'
-    assert img.size == (100,100)
+    assert img.palette.palette == '\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00'
+    assert img.size == (100, 100)
 
-    legend = renderer.get_legend(20,20)
+    legend = renderer.get_legend(20, 20)
     assert len(legend) == 3
     for index, element in enumerate(legend):
         element.image.save(str(tmpdir.join("classified_legend_%i.png" % index)))
 
     assert cmp(renderer.serialize(), {
-        'colors': [(10, '#FF0000'), (50, '#00FF00'), (99.0, '#0000FF')],
+        'colors': [(10, '#F00'), (50, '#0F0'), (99.0, '#00F')],
         'type': 'classified'
     }) == 0
 
 
 def test_uniquevalues_renderer(tmpdir):
-    data = numpy.zeros((100,100))
+    data = numpy.zeros((100, 100))
     data[10:25] = 10
     data[35:50] = 25
     data[50:75] = 50
     data[85:100] = 100
     colors = (
-        (10, Color(255,0,0,255)),
-        (25, Color(255,255,255,255)),
-        (50, Color(0,255,0,255)),
-        (100, Color(0,0,255,255))
+        (10, Color(255, 0, 0, 255)),
+        (25, Color(255, 255, 255, 255)),
+        (50, Color(0, 255, 0, 255)),
+        (100, Color(0, 0, 255, 255))
     )
     labels = ('A', 'B', 'C', 'D')
-
 
     renderer = UniqueValuesRenderer(colors, labels=labels)
 
@@ -90,19 +89,20 @@ def test_uniquevalues_renderer(tmpdir):
 
     img = renderer.render_image(data)
     img.save(str(tmpdir.join("unique.png")))
-    assert img.palette.palette == '\xff\x00\x00\xff\xff\xff\x00\xff\x00\x00\x00\xff'
-    assert img.size == (100,100)
-    legend = renderer.get_legend(20,20)
+    assert img.palette.palette == '\xff\x00\x00\xff\xff\xff\x00\xff\x00\x00\x00\xff\x00\x00\x00'
+    assert img.size == (100, 100)
+    legend = renderer.get_legend(20, 20)
     assert len(legend) == 4
     for index, element in enumerate(legend):
-        element.image.save(str(tmpdir.join("uniquevalues_legend_%i.png" % index)))
+        element.image.save(
+            str(tmpdir.join("uniquevalues_legend_%i.png" % index)))
 
     assert cmp(renderer.serialize(), {
         'colors': [
-            (10, '#FF0000'),
-            (25, '#FFFFFF'),
-            (50, '#00FF00'),
-            (100, '#0000FF')],
+            (10, '#F00'),
+            (25, '#FFF'),
+            (50, '#0F0'),
+            (100, '#00F')],
         'type': 'unique',
         'options': {
             'labels': ('A', 'B', 'C', 'D')
@@ -111,15 +111,15 @@ def test_uniquevalues_renderer(tmpdir):
 
 
 def test_get_renderers_by_name():
-    data = numpy.zeros((100,100))
+    data = numpy.zeros((100, 100))
     for i in range(0, 100):
         data[i] = i
     colors = (
-        (10, Color(255,0,0,255)),
-        (50, Color(0,255,0,255)),
-        (data.max(), Color(0,0,255,255))
+        (10, Color(255, 0, 0, 255)),
+        (50, Color(0, 255, 0, 255)),
+        (data.max(), Color(0, 0, 255, 255))
     )
     renderer = get_renderer_by_name("classified")(colors)
     img = renderer.render_image(data)
-    assert img.palette.palette == '\xff\x00\x00\x00\xff\x00\x00\x00\xff'
-    assert img.size == (100,100)
+    assert img.palette.palette == '\xff\x00\x00\x00\xff\x00\x00\x00\xff\x00\x00\x00'
+    assert img.size == (100, 100)

--- a/clover/render/renderers/unique.py
+++ b/clover/render/renderers/unique.py
@@ -26,7 +26,6 @@ class UniqueValuesRenderer(RasterRenderer):
         else:
             self.labels = []
 
-
     def get_legend(self, image_width=20, image_height=20):
         legend_elements = []
         if self.labels:
@@ -43,39 +42,25 @@ class UniqueValuesRenderer(RasterRenderer):
             ))
         return legend_elements
 
-
     def render_image(self, data, row_major_order=True):
-        img_size = data.shape[::-1] if row_major_order else data.shape[:2] # have to invert because PIL thinks about this backwards
         values = self._mask_fill_value(data.ravel())
-        mask = values.mask
 
         max_value = max(values.max(), self.values.max())
         if values.dtype.kind == 'u' and max_value < 65536:
-            palette_indices = numpy.zeros(max_value + 1)
-            palette_indices.fill(-1)
+            palette_indices = numpy.zeros(max_value + 1, dtype=numpy.uint8)
+            palette_indices.fill(self.values.shape[0])
             for index, value in enumerate(self.values):
                 palette_indices.itemset(value, index)
-            palette_indices = numpy.ma.masked_array(palette_indices, mask=palette_indices == -1).astype(numpy.uint16)
             image_data = palette_indices[values].astype(numpy.uint8)
-            mask = numpy.logical_or(mask, image_data.mask)
         else:
-            image_data = numpy.zeros(values.shape).astype(numpy.int)
-            image_data.fill(-1)
+            image_data = numpy.zeros(values.shape, dtype=numpy.uint8)
+            image_data.fill(self.values.shape[0])
             for index, value in enumerate(self.values):
                 image_data[values == value] = index
-            mask = numpy.logical_or(mask, image_data == -1)
-            image_data = image_data.astype(numpy.uint8)
 
-        if self.background_color:
-            image_data[values.mask] = self.palette.shape[0]
-
-        img = Image.frombuffer("P", img_size, image_data, "raw", "P", 0, 1)
-        self._set_image_palette(img)
-        if self.background_color is None and mask.shape:
-            img = self._apply_transparency_mask_to_image(img, (mask == False))
-
-        return img
-
+         # have to invert dimensions because PIL thinks about this backwards
+        size = data.shape[::-1] if row_major_order else data.shape[:2]
+        return self._create_image(image_data, size)
 
     def _generate_palette(self):
         self.palette = numpy.asarray([entry[1].to_tuple() for entry in self.colormap]).astype(numpy.uint8)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 Numpy
 netCDF4>=1.1.1
 affine>=1.0
-Pillow>=2.7.0
+Pillow>=2.9.0
 six
 rasterio>=0.26
 click
 pytz
 palettable
 pyproj
-jinja2
-shapely
+jinja2shapely
 fiona>=1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ click
 pytz
 palettable
 pyproj
-jinja2shapely
+jinja2
+shapely
 fiona>=1.6.0


### PR DESCRIPTION
Note the upgrade required for Pillow.

We can now set the transparency value into the palette and image info, and keep a paletted image instead of converting to RGBA (slower and larger).

Updated tests to match, but we are still from full coverage tests of these changes.