### PR TITLE
Generate coordinate vars using index instead of accumulation

### DIFF
--- a/clover/netcdf/variable.py
+++ b/clover/netcdf/variable.py
@@ -327,7 +327,7 @@ class SpatialCoordinateVariables(object):
 
         y_arr = numpy.arange(0, -y_size, -1, dtype=dtype)
         y_arr *= y_pixel_size
-        y_arr += (bbox.ymax - x_pixel_size / 2.0)
+        y_arr += (bbox.ymax - y_pixel_size / 2.0)
 
         x = SpatialCoordinateVariable(x_arr)
         y = SpatialCoordinateVariable(y_arr)

--- a/clover/netcdf/variable.py
+++ b/clover/netcdf/variable.py
@@ -320,8 +320,17 @@ class SpatialCoordinateVariables(object):
 
         x_pixel_size = (bbox.xmax - bbox.xmin) / float(x_size)
         y_pixel_size = (bbox.ymax - bbox.ymin) / float(y_size)
-        x = SpatialCoordinateVariable(numpy.arange(bbox.xmin + (x_pixel_size / 2.0), bbox.xmax, x_pixel_size, dtype=dtype))
-        y = SpatialCoordinateVariable(numpy.arange(bbox.ymax - (y_pixel_size / 2.0), bbox.ymin, -y_pixel_size, dtype=dtype))
+
+        x_arr = numpy.arange(x_size, dtype=dtype)
+        x_arr *= x_pixel_size
+        x_arr += (bbox.xmin + x_pixel_size / 2.0)
+
+        y_arr = numpy.arange(0, -y_size, -1, dtype=dtype)
+        y_arr *= y_pixel_size
+        y_arr += (bbox.ymax - x_pixel_size / 2.0)
+
+        x = SpatialCoordinateVariable(x_arr)
+        y = SpatialCoordinateVariable(y_arr)
 
         return SpatialCoordinateVariables(x, y, bbox.projection)
 


### PR DESCRIPTION
Currently, values for the coordinate variables are calculated using the cell resolution, starting from the lower-left, using `numpy.arange`. This causes precision-related errors when the resolution is a highly precise number, as `arange` uses accumulated value to determine the value of each new cell. This means that when calculating the last value in an array, `arange` will take the penultimate value and append the step value to it to determine the last value. As a result, rounding inaccuracies add up to potentially large differences for large arrays.

The fix in this PR is to calculate each coordinate in the coord arrays independently. This is done by first creating an array of indices, the multiplying those by the step value and adding the starting value. This way, precision errors are not accumulated along the way.