### PR TITLE
Fix coordinate index from range slice / bounding box

### DIFF
--- a/clover/netcdf/tests/test_variable.py
+++ b/clover/netcdf/tests/test_variable.py
@@ -48,6 +48,13 @@ def test_range_functions():
     assert numpy.array_equal(variable.slice_by_range(40, 50), numpy.array([]))
 
 
+def test_window_for_bbox():
+    coords = SpatialCoordinateVariables.from_bbox(BBox([-124, 82, -122, 90], Proj(init='epsg:4326')), 20, 20)
+    window = coords.get_window_for_bbox(BBox([-123.9, 82.4, -122.2, 89.6]))
+
+    assert window.x_slice == slice(1, 19)
+    assert window.y_slice == slice(1, 19)
+
 
 def test_BoundsCoordinateVariable():
     bounds = numpy.array(((0, 1), (1, 2)))

--- a/clover/netcdf/variable.py
+++ b/clover/netcdf/variable.py
@@ -61,8 +61,8 @@ class CoordinateVariable(object):
         if self.is_ascending_order():
             start_index = min(self.values.searchsorted(start), self.values.size - 1)
 
-            # Need to move 1 index to the left unless we matched an index exactly
-            if start_index > 0 and start < self.values[start_index]:
+            # Need to move 1 index to the left unless we matched an index closely (allowing for precision errors)
+            if start_index > 0 and not numpy.isclose(start, self.values[start_index]):
                 start_index -= 1
             stop_index = self.values.searchsorted(stop)
             if stop_index >= self.values.size:
@@ -72,7 +72,7 @@ class CoordinateVariable(object):
             # If values are not ascending, they need to be reversed
             temp = self.values[::-1]
             start_index = min(temp.searchsorted(start), temp.size - 1)
-            if start_index > 0 and start < temp[start_index]:
+            if start_index > 0 and not numpy.isclose(start, temp[start_index]):
                 start_index -= 1
             stop_index = temp.searchsorted(stop)
             size = self.values.size - 1
@@ -403,8 +403,11 @@ class SpatialCoordinateVariables(object):
 
         assert isinstance(bbox, BBox)
 
-        y_offset, y_max = self.y.indices_for_range(bbox.ymin, bbox.ymax)
-        x_offset, x_max =  self.x.indices_for_range(bbox.xmin, bbox.xmax)
+        y_half_pixel_size = float(self.y.pixel_size)/2
+        x_half_pixel_size = float(self.x.pixel_size)/2
+
+        y_offset, y_max = self.y.indices_for_range(bbox.ymin + y_half_pixel_size, bbox.ymax - y_half_pixel_size)
+        x_offset, x_max =  self.x.indices_for_range(bbox.xmin + x_half_pixel_size, bbox.xmax - x_half_pixel_size)
         return Window((y_offset, y_max + 1), (x_offset, x_max + 1))
 
 


### PR DESCRIPTION
This PR fixes a couple problems with finding slice indices from a value range and with creating a window from a bounding box

## 1. Slice indices from value range
The problem with the slice indices lies in comparison of exact floats:

```python
# Need to move 1 index to the left unless we matched an index exactly
if start_index > 0 and start < self.values[start_index]:
    start_index -= 1
```

This logic decrements the index unless the result of `searchsorted` exactly matches the start of the range. However, due to float precision errors, the condition `start < self.values[start_index]` almost never evaluates `False`, even when two floats should be considered equal, but are off by a small amount due to precision errors.

The solution is to use numpy's `isclose` function to do this comparison instead which allows for equality comparison with precision errors.

## 2. Window from bbox
The problem with creating a window from a bounding box happens because the cells of a raster are referenced from the center of the cell, whereas a bounding box is understood to be the outer bounds of the raster. The current logic creates too big a window, as it treats cell edges as if they were center points.

This fix simply transforms the bounding box's edge coordinates to the coordinate values' center coordinates by adding half a pixel to x/y min and subtracting half a pixel from x/y max.