### PR TITLE
Adjust stop index downward for inexact matches

### DIFF
--- a/clover/netcdf/tests/test_variable.py
+++ b/clover/netcdf/tests/test_variable.py
@@ -50,7 +50,7 @@ def test_range_functions():
 
 def test_window_for_bbox():
     coords = SpatialCoordinateVariables.from_bbox(BBox([-124, 82, -122, 90], Proj(init='epsg:4326')), 20, 20)
-    window = coords.get_window_for_bbox(BBox([-123.9, 82.4, -122.2, 89.6]))
+    window = coords.get_window_for_bbox(BBox([-123.9, 82.4, -122.1, 89.6]))
 
     assert window.x_slice == slice(1, 19)
     assert window.y_slice == slice(1, 19)
@@ -109,11 +109,11 @@ def test_SpatialCoordinateVariables_slice_by_bbox():
     proj = Proj(init='EPSG:4326')
     coords = SpatialCoordinateVariables(lon, lat, proj)
 
-    subset = coords.slice_by_bbox(BBox((2.25, 4.1, 5.7, 16.2), proj))
-    assert numpy.array_equal(subset.x.values, numpy.arange(2, 7))
+    subset = coords.slice_by_bbox(BBox((1.75, 3.7, 6.2, 16.7), proj))
+    assert numpy.array_equal(subset.x.values, numpy.arange(2, 6))
     assert subset.x.values[0] == 2
-    assert subset.x.values[-1] == 6
-    assert subset.y.values[0] == 17
+    assert subset.x.values[-1] == 5
+    assert subset.y.values[0] == 16
     assert subset.y.values[-1] == 4
 
 

--- a/clover/netcdf/variable.py
+++ b/clover/netcdf/variable.py
@@ -374,9 +374,16 @@ class SpatialCoordinateVariables(object):
     def slice_by_bbox(self, bbox):
         assert isinstance(bbox, BBox)
 
+        x_half_pixel_size = float(self.x.pixel_size)/2
+        y_half_pixel_size = float(self.y.pixel_size)/2
+
         # Note: this is very sensitive to decimal precision.
-        x = SpatialCoordinateVariable(self.x.slice_by_range(bbox.xmin, bbox.xmax))
-        y = SpatialCoordinateVariable(self.y.slice_by_range(bbox.ymin, bbox.ymax))
+        x = SpatialCoordinateVariable(
+            self.x.slice_by_range(bbox.xmin + x_half_pixel_size, bbox.xmax - x_half_pixel_size)
+        )
+        y = SpatialCoordinateVariable(
+            self.y.slice_by_range(bbox.ymin + y_half_pixel_size, bbox.ymax - y_half_pixel_size)
+        )
         return SpatialCoordinateVariables(x, y, self.projection)
 
     def slice_by_window(self, window):

--- a/clover/netcdf/variable.py
+++ b/clover/netcdf/variable.py
@@ -64,17 +64,24 @@ class CoordinateVariable(object):
             # Need to move 1 index to the left unless we matched an index closely (allowing for precision errors)
             if start_index > 0 and not numpy.isclose(start, self.values[start_index]):
                 start_index -= 1
-            stop_index = self.values.searchsorted(stop)
-            if stop_index >= self.values.size:
+
+            stop_index = min(self.values.searchsorted(stop), self.values.size - 1)
+            if not numpy.isclose(stop, self.values[stop_index]) and stop < self.values[stop_index]:
                 stop_index -= 1
+
             return start_index, stop_index
         else:
             # If values are not ascending, they need to be reversed
             temp = self.values[::-1]
             start_index = min(temp.searchsorted(start), temp.size - 1)
+
             if start_index > 0 and not numpy.isclose(start, temp[start_index]):
                 start_index -= 1
-            stop_index = temp.searchsorted(stop)
+
+            stop_index = min(temp.searchsorted(stop), temp.size - 1)
+            if not numpy.isclose(stop, temp[stop_index]) and stop < temp[stop_index]:
+                stop_index -= 1
+
             size = self.values.size - 1
             return max(size - stop_index, 0), max(size - start_index, 0)
 


### PR DESCRIPTION
This is a follow up to #44. The stop index also needs to be adjusted downward for inexact matches.