### PR TITLE
Correctly handle writing datasets with year intervals

### DIFF
--- a/clover/cli/convert.py
+++ b/clover/cli/convert.py
@@ -69,7 +69,7 @@ def to_netcdf(
 
     # TODO: add format string template to this to parse out components
 
-    filenames = glob.glob(files)
+    filenames = list(glob.glob(files))
     if not filenames:
         raise click.BadParameter('No files found matching that pattern', param='files', param_hint='FILES')
 

--- a/clover/netcdf/variable.py
+++ b/clover/netcdf/variable.py
@@ -459,7 +459,7 @@ class DateVariable(CoordinateVariable):
             else:
                 raise ValueError('Variable is missing required attributes: units, calendar')
         else:
-            self.units = '{0}s since {1}'.format(self.unit, str(units_start_date))
+            self.units = 'year' if self.unit == 'year' else '{0}s since {1}'.format(self.unit, str(units_start_date))
             self.calendar = calendar
 
             if self.values.dtype.kind in ('i', 'u', 'f'):
@@ -467,7 +467,12 @@ class DateVariable(CoordinateVariable):
             elif isinstance(self.values[0], datetime):
                 self.dates = self.values.copy()
 
-            self.values = numpy.array(date2num(self.dates, units=self.units, calendar=self.calendar), dtype=numpy.int32)
+            if self.unit == 'year':
+                self.values = numpy.array([x.year for x in self.values], dtype='int32')
+            else:
+                self.values = numpy.array(
+                    date2num(self.dates, units=self.units, calendar=self.calendar), dtype=numpy.int32
+                )
 
     @property
     def datetimes(self):


### PR DESCRIPTION
This PR modifies the `DateVariable` constructor to write units in terms of `years`, instead of the `<unit> since <start date>` used for other units.

Using `years since <date>` is not supported by convention and causes problems elsewhere, whereas `years` seems to be handled reasonably well.