### PR TITLE
Find variable min/max one slice at a time to reduce memory errors

### DIFF
--- a/clover/netcdf/describe.py
+++ b/clover/netcdf/describe.py
@@ -64,14 +64,18 @@ def describe(path_or_dataset):
         }
 
         if dtype not in ('str', ):
-            try:
+            if len(variable.shape) > 2:
+                # Avoid loading the entire array into memory by iterating along the first index (usually time)
+                variable_info.update({
+                    'min': min(variable[i, :].min().item() for i in range(variable.shape[0])),
+                    'max': max(variable[i, :].max().item() for i in range(variable.shape[0]))
+                })
+            else:
                 data = variable[:]
                 variable_info.update({
                     'min': data.min().item(),
                     'max': data.max().item()
                 })
-            except MemoryError:
-                pass  # TODO: find a better way to handle this
 
         if variable_name in dataset.dimensions and dtype not in ('str', ):
             dimension_variable = dataset.variables[variable_name]


### PR DESCRIPTION
This PR adjusts the `describe` logic when determining variable min/max values. Previously, the function would silently ignore memory errors, resulting in a describe that would succeed, but with no min/max values.

The new logic loads one slice at a time of the first dimension (usually time) when there are more than two dimensions. This logic is far from perfect, but should cover many cases until a better solution can be developed.

While it would be possible to make this change and keep the silent memory error handling, IMHO this makes problems more difficult to diagnose when client code is depending on min/max values. However, I'm open to other points of view on this.